### PR TITLE
Add timeout to calls

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,6 +16,7 @@ class Connection extends EventEmitter {
   get socket() {
     return this._socket;
   }
+    
 
   constructor(host, port = 23) {
     super();
@@ -48,21 +49,10 @@ class Connection extends EventEmitter {
     });
   }
 
-  timeout(milliseconds) {
-    return new Promise(() => {
-      setTimeout(() => {
-        const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
-        return Promise.reject(timeoutRejectionError);
-      }, milliseconds); // Wait ms then resolve.
-    });
-  }
-
-  write(command, timeout = 10 * 1000) {
-    const writePromise = new Promise((resolve) => {
+  write(command) {
+    return new Promise((resolve) => {
       this.socket.write(`${command}\r`, 'ascii', resolve);
     });
-    const timeoutPromise = this.timeout(timeout);
-    return Promise.race([writePromise, timeoutPromise]);
   }
 
   connect()

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ class Connection extends EventEmitter {
   get socket() {
     return this._socket;
   }
-    
+
 
   constructor(host, port = 23) {
     super();
@@ -49,10 +49,22 @@ class Connection extends EventEmitter {
     });
   }
 
+  timeout(milliseconds) {
+    return new Promise(() => {
+        setTimeout(() => {
+          console.log('reject because of delay!'); // eslint-disable-line
+          // resolve();
+          return Promise.reject('Timed out!');
+        }, milliseconds); // Wait 1s then resolve.
+      });
+  }
+
   write(command) {
-    return new Promise((resolve) => {
+    const writePromise = new Promise((resolve) => {
       this.socket.write(`${command}\r`, 'ascii', resolve);
     });
+    const timeoutPromise = this.timeout(10*1000);
+    return Promise.race([writePromise, timeoutPromise]);
   }
 
   connect()

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -17,7 +17,6 @@ class Connection extends EventEmitter {
     return this._socket;
   }
 
-
   constructor(host, port = 23) {
     super();
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -51,11 +51,11 @@ class Connection extends EventEmitter {
 
   timeout(milliseconds) {
     return new Promise(() => {
-        setTimeout(() => {
-          console.log('reject because of delay!'); // eslint-disable-line
-          return Promise.reject('Timed out!');
-        }, milliseconds); // Wait 1s then resolve.
-      });
+      setTimeout(() => {
+        const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
+        return Promise.reject(timeoutRejectionError);
+      }, milliseconds); // Wait ms then resolve.
+    });
   }
 
   write(command, timeout = 10 * 1000) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,17 +53,16 @@ class Connection extends EventEmitter {
     return new Promise(() => {
         setTimeout(() => {
           console.log('reject because of delay!'); // eslint-disable-line
-          // resolve();
           return Promise.reject('Timed out!');
         }, milliseconds); // Wait 1s then resolve.
       });
   }
 
-  write(command) {
+  write(command, timeout = 10 * 1000) {
     const writePromise = new Promise((resolve) => {
       this.socket.write(`${command}\r`, 'ascii', resolve);
     });
-    const timeoutPromise = this.timeout(10*1000);
+    const timeoutPromise = this.timeout(timeout);
     return Promise.race([writePromise, timeoutPromise]);
   }
 

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -175,9 +175,10 @@ class DenonClient extends Connection {
    * @method sendCommand
    * @param  {string} command   [The command]
    * @param  {string} parameter [The parameter]
+   * @param  {number} timeout [The length of time to wait for a response]
    * @return {Promise} [A response]
    */
-  sendCommand(command, parameter, hook) {
+  sendCommand(command, parameter, hook, timeout = 10) {
     return new Promise((resolve) => {
 
       if (typeof hook === 'string') {
@@ -187,7 +188,7 @@ class DenonClient extends Connection {
       }
 
       return this
-        .write(`${command}${parameter}`)
+        .write(`${command}${parameter}`, timeout)
         .then(() => {
           if (typeof hook === 'undefined') {
             resolve();

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -183,6 +183,7 @@ class DenonClient extends Connection {
 
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
+          console.log('command result: ', result);
           resolve(result);
         });
       }
@@ -192,6 +193,7 @@ class DenonClient extends Connection {
         .then((result) => {
           console.log('denon result: ', result);
           if (typeof hook === 'undefined') {
+            console.log('command undefined resolve');
             resolve();
           }
         });
@@ -204,8 +206,10 @@ class DenonClient extends Connection {
 
   timeout(milliseconds) {
     return new Promise((resolve, reject) => {
+      console.log('start timeout');
       setTimeout(() => {
         const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
+        console.log('timeout rejection');
         reject(timeoutRejectionError);
       }, milliseconds); // Wait ms then resolve
     });

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -190,7 +190,7 @@ class DenonClient extends Connection {
       return this
         .write(`${command}${parameter}`)
         .then((result) => {
-          console.log('result: ', result);
+          console.log('denon result: ', result);
           if (typeof hook === 'undefined') {
             resolve();
           }

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -203,10 +203,10 @@ class DenonClient extends Connection {
   }
 
   timeout(milliseconds) {
-    return new Promise(() => {
+    return new Promise((resolve, reject) => {
       setTimeout(() => {
         const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
-        return Promise.reject(timeoutRejectionError);
+        reject(timeoutRejectionError);
       }, milliseconds); // Wait ms then resolve
     });
   }

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -189,7 +189,8 @@ class DenonClient extends Connection {
 
       return this
         .write(`${command}${parameter}`, timeout)
-        .then(() => {
+        .then((result) => {
+          console.log('result: ', result);
           if (typeof hook === 'undefined') {
             resolve();
           }

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -175,10 +175,10 @@ class DenonClient extends Connection {
    * @method sendCommand
    * @param  {string} command   [The command]
    * @param  {string} parameter [The parameter]
-   * @param  {number} timeout [The length of time to wait for a response]
+   * @param  {number} timeout [The length of time in ms to wait for a response]
    * @return {Promise} [A response]
    */
-  sendCommand(command, parameter, hook, timeout = 10) {
+  sendCommand(command, parameter, hook, timeout = 10*1000) {
     return new Promise((resolve) => {
 
       if (typeof hook === 'string') {

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -209,7 +209,7 @@ class DenonClient extends Connection {
       console.log('start timeout');
       setTimeout(() => {
         // const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
-        // console.log('timeout rejection');
+        console.log('timeout resolution');
         // resolve(timeoutRejectionError);
         resolve();
       }, milliseconds); // Wait ms then resolve

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -208,9 +208,10 @@ class DenonClient extends Connection {
     return new Promise((resolve, reject) => {
       console.log('start timeout');
       setTimeout(() => {
-        const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
-        console.log('timeout rejection');
-        reject(timeoutRejectionError);
+        // const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
+        // console.log('timeout rejection');
+        // resolve(timeoutRejectionError);
+        resolve();
       }, milliseconds); // Wait ms then resolve
     });
   }

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -179,7 +179,7 @@ class DenonClient extends Connection {
    * @return {Promise} [A response]
    */
   sendCommand(command, parameter, hook, timeout = 10*1000) {
-    return new Promise((resolve) => {
+    const commandPromise = new Promise((resolve) => {
 
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
@@ -188,14 +188,27 @@ class DenonClient extends Connection {
       }
 
       return this
-        .write(`${command}${parameter}`, timeout)
+        .write(`${command}${parameter}`)
         .then((result) => {
           console.log('result: ', result);
           if (typeof hook === 'undefined') {
             resolve();
           }
         });
-    })
+    });
+
+    const timeoutPromise = this.timeout(timeout);
+
+    return Promise.race([commandPromise, timeoutPromise]);
+  }
+
+  timeout(milliseconds) {
+    return new Promise(() => {
+      setTimeout(() => {
+        const timeoutRejectionError = new Error(`Timeout out after ${milliseconds} ms.`);
+        return Promise.reject(timeoutRejectionError);
+      }, milliseconds); // Wait ms then resolve
+    });
   }
 
   /**


### PR DESCRIPTION
I added a timeout to all write commands at the connection level. The denon receiver only outputs a response when the command causes a change. So sending the same command consecutively causes the framework to get stuck waiting for a response that will never arrive.

Eventually I'd like to add a status command matching the original base letters, to trick the receiver into responding to the call. But I wanted to break this up into two pieces for the moment.