### PR TITLE
Added timeouts to framework for sending commands

### DIFF
--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -182,7 +182,6 @@ class DenonClient extends Connection {
     return new Promise((resolve, reject) => {
 
       let timeoutID = null;
-
       const cleanUpTimeout = (timer) => {
         if (timer) {
           clearTimeout(timer);
@@ -192,25 +191,20 @@ class DenonClient extends Connection {
 
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
-          console.log('callback with result: ', result);
-          console.log('check timeout');
           cleanUpTimeout(timeoutID);
           resolve(result);
         });
       }
 
       timeoutID = setTimeout(() => {
-        console.error('timed out!');
-        const timeoutRejectionError = new Error(`Timeout out after ${timeout} ms.`);
+        const timeoutRejectionError = new Error(`Timed out after ${timeout} ms.`);
         reject(timeoutRejectionError);
       }, timeout);
 
       return this
         .write(`${command}${parameter}`)
         .then(() => {
-          console.log('after write');
           if (typeof hook === 'undefined') {
-            console.log('check timeout');
             cleanUpTimeout(timeoutID);
             resolve();
           }

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -175,9 +175,10 @@ class DenonClient extends Connection {
    * @method sendCommand
    * @param  {string} command   [The command]
    * @param  {string} parameter [The parameter]
+   * @param  {number} timeout [The length of time to await a response]
    * @return {Promise} [A response]
    */
-  sendCommand(command, parameter, hook) {
+  sendCommand(command, parameter, hook, timeout = 10*1000) {
     return new Promise((resolve, reject) => {
 
       let timeoutID = null;
@@ -200,8 +201,9 @@ class DenonClient extends Connection {
 
       timeoutID = setTimeout(() => {
         console.error('timed out!');
-        reject('time out');
-      }, 10*1000);
+        const timeoutRejectionError = new Error(`Timeout out after ${timeout} ms.`);
+        reject(timeoutRejectionError);
+      }, timeout);
 
       return this
         .write(`${command}${parameter}`)

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -178,22 +178,31 @@ class DenonClient extends Connection {
    * @return {Promise} [A response]
    */
   sendCommand(command, parameter, hook) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+
+      let timeoutID;
 
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
+          clearTimeout(timeoutID);
           resolve(result);
         });
       }
+
+      timeoutID = setTimeout(() => {
+        console.error('timed out!');
+        reject('time out');
+      }, 10*1000);
 
       return this
         .write(`${command}${parameter}`)
         .then(() => {
           if (typeof hook === 'undefined') {
+            clearTimeout(timeoutID);
             resolve();
           }
         });
-    })
+    });
   }
 
   /**

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -180,11 +180,17 @@ class DenonClient extends Connection {
   sendCommand(command, parameter, hook) {
     return new Promise((resolve, reject) => {
 
-      let timeoutID;
+      let timeoutID = null;
 
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
-          clearTimeout(timeoutID);
+          console.log('callback with result: ', result);
+          console.log('check timeout');
+          if (timeoutID) {
+            console.log('clear timeout');
+            timeoutID = null;
+            clearTimeout(timeoutID);
+          }
           resolve(result);
         });
       }
@@ -197,8 +203,14 @@ class DenonClient extends Connection {
       return this
         .write(`${command}${parameter}`)
         .then(() => {
+          console.log('after write');
           if (typeof hook === 'undefined') {
-            clearTimeout(timeoutID);
+            console.log('check timeout');
+            if (timeoutID) {
+              console.log('clear timeout');
+              timeoutID = null;
+              clearTimeout(timeoutID);
+            }
             resolve();
           }
         });

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -197,7 +197,7 @@ class DenonClient extends Connection {
       }
 
       timeoutID = setTimeout(() => {
-        const timeoutRejectionError = new Error(`Timed out after ${timeout} ms.`);
+        const timeoutRejectionError = new Error(`Timed out (command,paramter) (${command},${parameter}) after ${timeout} ms.`);
         reject(timeoutRejectionError);
       }, timeout);
 

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -182,15 +182,18 @@ class DenonClient extends Connection {
 
       let timeoutID = null;
 
+      const cleanUpTimeout = (timer) => {
+        if (timer) {
+          timer = null;
+          clearTimeout(timer);
+        }
+      };
+
       if (typeof hook === 'string') {
         this.once(hook, (result) => {
           console.log('callback with result: ', result);
           console.log('check timeout');
-          if (timeoutID) {
-            console.log('clear timeout');
-            timeoutID = null;
-            clearTimeout(timeoutID);
-          }
+          cleanUpTimeout(timeoutID);
           resolve(result);
         });
       }
@@ -206,11 +209,7 @@ class DenonClient extends Connection {
           console.log('after write');
           if (typeof hook === 'undefined') {
             console.log('check timeout');
-            if (timeoutID) {
-              console.log('clear timeout');
-              timeoutID = null;
-              clearTimeout(timeoutID);
-            }
+            cleanUpTimeout(timeoutID);
             resolve();
           }
         });

--- a/lib/denon_client.js
+++ b/lib/denon_client.js
@@ -184,8 +184,8 @@ class DenonClient extends Connection {
 
       const cleanUpTimeout = (timer) => {
         if (timer) {
-          timer = null;
           clearTimeout(timer);
+          timer = null;
         }
       };
 


### PR DESCRIPTION
Discovered in the Denon spec sheet that the receiver only outputs a response when a command is sent that causes a change in state.

This framework only resolves promises when no hook/callback is provided, or an expected response is received. This means that sending a `setInput` with the same value twice in a row to the receiver will cause the promise chain in this framework to hang indefinitely.

Fixed this with a timeout that is set to a default of 10 seconds.